### PR TITLE
added flat hierarchy prompt / option for view templates

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,14 +1,14 @@
 'use strict';
+
 var util = require('util');
 var path = require('path');
 var open = require('open');
 var chalk = require('chalk');
 var yeoman = require('yeoman-generator');
 
-
 var MeteorGenerator = module.exports = function MeteorGenerator(args, options, config) {
   yeoman.generators.Base.apply(this, arguments);
-
+  
   this.on('end', function () {
     console.log('\n' + chalk.cyan.bold('All set!') + ' Run ' + chalk.yellow.bold('meteor') + ' to start your app.');
     // meteor
@@ -38,17 +38,27 @@ MeteorGenerator.prototype.askFor = function askFor() {
       message: 'Describe this project briefly'
     },
     {
+      type: 'confirm',
+      name: 'flatHierarchyViews',
+      message: 'Use flat hierarchy for views?',
+      default: false
+    },
+    {
       type: 'list',
       name: 'cssPreprocessor',
       message: 'Choose a CSS Preprocessor',
       choices: ['stylus', 'less', 'bootstrap', 'none']
-    }
+    },
   ];
 
   this.prompt(prompts, function (props) {
     this.projectName = props.projectName;
     this.projectSummary = props.projectSummary;
+    this.flatHierarchyViews = props.flatHierarchyViews;
     this.cssPreprocessor = props.cssPreprocessor;
+    
+    this.config.set('flatHierarchyViews', this.flatHierarchyViews);
+    this.config.save();
 
     cb();
   }.bind(this));
@@ -70,12 +80,19 @@ MeteorGenerator.prototype.client = function app() {
   this.mkdir('client');
   this.mkdir('client/vendor');
   this.mkdir('client/views');
-  this.mkdir('client/views/layout');
-  this.mkdir('client/views/loading');
+  if (this.flatHierarchyViews === false) {
+    this.mkdir('client/views/layout');
+    this.mkdir('client/views/loading');
+  }
   this.copy('client/main.coffee', 'client/main.coffee');
   this.copy('client/router.coffee', 'client/router.coffee');
-  this.copy('client/views/layout/layout.html', 'client/views/layout/layout.html');
-  this.copy('client/views/loading/loading.html', 'client/views/loading/loading.html');
+  if (this.flatHierarchyViews === false) {
+    this.copy('client/views/layout/layout.html', 'client/views/layout/layout.html');
+    this.copy('client/views/loading/loading.html', 'client/views/loading/loading.html');
+  } else {
+    this.copy('client/views/layout/layout.html', 'client/views/layout.html');
+    this.copy('client/views/loading/loading.html', 'client/views/loading.html');
+  }
 };
 
 MeteorGenerator.prototype.server = function app() {

--- a/app/index.js
+++ b/app/index.js
@@ -38,10 +38,14 @@ MeteorGenerator.prototype.askFor = function askFor() {
       message: 'Describe this project briefly'
     },
     {
-      type: 'confirm',
-      name: 'flatHierarchyViews',
-      message: 'Use flat hierarchy for views?',
-      default: false
+      type: 'list',
+      name: 'viewHierarchy',
+      message: 'How would you like your views to be organized?',
+      choices: [
+        { name: 'Nested: Each pair of .html and .coffee template files gets its own directory', value: 'nested' },
+        { name: 'Flat: All .html and .coffee template files share the same directory', value: 'flat' }
+      ],
+      default: 'nested'
     },
     {
       type: 'list',
@@ -54,10 +58,10 @@ MeteorGenerator.prototype.askFor = function askFor() {
   this.prompt(prompts, function (props) {
     this.projectName = props.projectName;
     this.projectSummary = props.projectSummary;
-    this.flatHierarchyViews = props.flatHierarchyViews;
+    this.viewHierarchy = props.viewHierarchy;
     this.cssPreprocessor = props.cssPreprocessor;
     
-    this.config.set('flatHierarchyViews', this.flatHierarchyViews);
+    this.config.set('viewHierarchy', this.viewHierarchy);
     this.config.save();
 
     cb();
@@ -80,13 +84,13 @@ MeteorGenerator.prototype.client = function app() {
   this.mkdir('client');
   this.mkdir('client/vendor');
   this.mkdir('client/views');
-  if (this.flatHierarchyViews === false) {
+  if (this.viewHierarchy == 'nested') {
     this.mkdir('client/views/layout');
     this.mkdir('client/views/loading');
   }
   this.copy('client/main.coffee', 'client/main.coffee');
   this.copy('client/router.coffee', 'client/router.coffee');
-  if (this.flatHierarchyViews === false) {
+  if (this.viewHierarchy == 'nested') {
     this.copy('client/views/layout/layout.html', 'client/views/layout/layout.html');
     this.copy('client/views/loading/loading.html', 'client/views/loading/loading.html');
   } else {

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -4,35 +4,79 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 
-
-describe('meteor generator', function () {
+describe('meteor coffee generator', function () {
     beforeEach(function (done) {
-        helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+        helpers.testDirectory(path.join(__dirname, 'tmp'), function (err) {
             if (err) {
                 return done(err);
             }
 
-            this.app = helpers.createGenerator('meteor:app', [
-                '../../app'
-            ]);
+            this.app = helpers.createGenerator('meteor-coffee:app',
+              ['../../app',
+              '../../view']
+            );
+            
+            this.view = helpers.createGenerator('meteor-coffee:view',
+              ['../../view'],
+              ['testview']
+            );
+            
             done();
         }.bind(this));
     });
 
-    it('creates expected files', function (done) {
-        var expected = [
-            // add files you expect to exist here.
-            '.jshintrc',
-            '.editorconfig'
-        ];
+    it('creates app with view templates inside a directory', function (done) {
+      helpers.mockPrompt(this.app, {
+        'flatHierarchyViews': false
+      });
+      this.app.run({}, function () {
+        helpers.assertFile([
+          'client/views/layout/layout.html',
+          'client/views/loading/loading.html',
+          'client/views/index/index.html',
+          'client/views/index/index.coffee',
+        ]);
+        done();
+      });
+    });
 
-        helpers.mockPrompt(this.app, {
-            'someOption': true
-        });
-        this.app.options['skip-install'] = true;
-        this.app.run({}, function () {
-            helpers.assertFiles(expected);
-            done();
-        });
+    it('creates app with view templates with a flat hierary', function (done) {
+
+      helpers.mockPrompt(this.app, {
+        'flatHierarchyViews': true
+      });
+      this.app.run({}, function () {
+        helpers.assertFile([
+          'client/views/layout.html',
+          'client/views/loading.html',
+          'client/views/index.html',
+          'client/views/index.coffee'
+        ]);
+        done();
+      });
+    });
+
+    it('creates view template inside a directory', function (done) {
+      this.view.config.set('flatHierarchyViews', false);
+      this.view.config.save();
+      this.view.run({}, function () {
+        helpers.assertFile([
+          'client/views/testview/testview.html',
+          'client/views/testview/testview.coffee',
+        ]);
+        done();
+      });
+    });
+    
+    it('creates view template with a flat hierary', function (done) {
+      this.view.config.set('flatHierarchyViews', true);
+      this.view.config.save();
+      this.view.run({}, function () {
+        helpers.assertFile([
+          'client/views/testview.html',
+          'client/views/testview.coffee'
+        ]);
+        done();
+      });
     });
 });

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -27,7 +27,7 @@ describe('meteor coffee generator', function () {
 
     it('creates app with view templates inside a directory', function (done) {
       helpers.mockPrompt(this.app, {
-        'flatHierarchyViews': false
+        'viewHierarchy': 'nested'
       });
       this.app.run({}, function () {
         helpers.assertFile([
@@ -43,7 +43,7 @@ describe('meteor coffee generator', function () {
     it('creates app with view templates with a flat hierary', function (done) {
 
       helpers.mockPrompt(this.app, {
-        'flatHierarchyViews': true
+        'viewHierarchy': 'flat'
       });
       this.app.run({}, function () {
         helpers.assertFile([
@@ -57,7 +57,7 @@ describe('meteor coffee generator', function () {
     });
 
     it('creates view template inside a directory', function (done) {
-      this.view.config.set('flatHierarchyViews', false);
+      this.view.config.set('viewHierarchy', 'nested');
       this.view.config.save();
       this.view.run({}, function () {
         helpers.assertFile([
@@ -69,7 +69,7 @@ describe('meteor coffee generator', function () {
     });
     
     it('creates view template with a flat hierary', function (done) {
-      this.view.config.set('flatHierarchyViews', true);
+      this.view.config.set('viewHierarchy', 'flat');
       this.view.config.save();
       this.view.run({}, function () {
         helpers.assertFile([

--- a/test/test-load.js
+++ b/test/test-load.js
@@ -3,7 +3,7 @@
 
 var assert = require('assert');
 
-describe('meteor generator', function () {
+describe('meteor coffee generator', function () {
     it('can be imported without blowing up', function () {
         var app = require('../app');
         assert(app !== undefined);

--- a/view/index.js
+++ b/view/index.js
@@ -6,14 +6,20 @@ var ViewGenerator = module.exports = function ViewGenerator(args, options, confi
   // By calling `NamedBase` here, we get the argument to the subgenerator call
   // as `this.name`.
   yeoman.generators.NamedBase.apply(this, arguments);
-
-  console.log('Creating a new ' + this.name + ' view.');
+  
+  console.log('Creating a new ' + this.name + ' view (flat: ' + this.flatHierarchyViews + ').');
 };
 
 util.inherits(ViewGenerator, yeoman.generators.NamedBase);
 
 ViewGenerator.prototype.files = function files() {
-  this.mkdir('client/views/' + this.name);
-  this.template('_index.html', 'client/views/' + this.name + '/' + this.name + '.html');
-  this.template('_index.coffee', 'client/views/' + this.name + '/' + this.name + '.coffee');
+  var subpath = '';
+  
+  if (this.config.get('flatHierarchyViews') === false) {
+    this.mkdir('client/views/' + this.name);
+    subpath = this.name + '/';
+  }
+  
+  this.template('_index.html', 'client/views/' + subpath + this.name + '.html');
+  this.template('_index.coffee', 'client/views/' + subpath + this.name + '.coffee');
 };

--- a/view/index.js
+++ b/view/index.js
@@ -7,7 +7,7 @@ var ViewGenerator = module.exports = function ViewGenerator(args, options, confi
   // as `this.name`.
   yeoman.generators.NamedBase.apply(this, arguments);
   
-  console.log('Creating a new ' + this.name + ' view (flat: ' + this.flatHierarchyViews + ').');
+  console.log('Creating a new ' + this.name + ' view.');
 };
 
 util.inherits(ViewGenerator, yeoman.generators.NamedBase);
@@ -15,7 +15,7 @@ util.inherits(ViewGenerator, yeoman.generators.NamedBase);
 ViewGenerator.prototype.files = function files() {
   var subpath = '';
   
-  if (this.config.get('flatHierarchyViews') === false) {
+  if (this.config.get('viewHierarchy') == 'nested') {
     this.mkdir('client/views/' + this.name);
     subpath = this.name + '/';
   }


### PR DESCRIPTION
app creation:
-  on app creation a prompt is shown asking if views should use a flat hierarchy or not
- default answer is no (to keep the previous behavior)
- if the answer is no: client/views/&lt;viewname&gt;/&lt;view name&gt;.{htmlcoffee} files are created
- if the answer is yes: client/views/&lt;viewname&gt;.{htmlcoffee} files are created

view creation:
- the value of the answer is stored in the config (flatHistoryView)
- on view creation the value (flatHistoryView) is read from the config
- if the answer is no: client/views/<name>/<name>.{htmlcoffee} files are created
- if the answer is yes: client/views/<name>.{htmlcoffee} files are created

unit tests:
- added unit tests for app creation
- added unit tests for view creation